### PR TITLE
Fix error "check_if_login_required has not been defined" when click on button Google

### DIFF
--- a/app/controllers/redmine_oauth_controller.rb
+++ b/app/controllers/redmine_oauth_controller.rb
@@ -1,4 +1,3 @@
-require 'account_controller'
 require 'json'
 
 class RedmineOauthController < AccountController


### PR DESCRIPTION
Hello on version 4.1 & 4.2 of redmine, when clicking on the google connection button, I get this error: 
`
FATAL -- : ArgumentError (Before process_action callback :check_if_login_required has not been defined):
`

The ruby [documentation](https://guides.rubyonrails.org/getting_started.html#autoloading) says : 

_Application classes and modules are available everywhere, you do not need and should not load anything under app with require. This feature is called autoloading, and you can learn more about it in [Autoloading and Reloading Constants](https://guides.rubyonrails.org/autoloading_and_reloading_constants.html)._

 or the file **redmine_oauth_controller.rb** file does a require on the account_controller file

The removal of the require function allows the plugin to work properly again 